### PR TITLE
security: fix 7 vulnerabilities found in audit

### DIFF
--- a/android/app/src/main/java/com/deutsia/pinfold/PrivacyHttpPlugin.java
+++ b/android/app/src/main/java/com/deutsia/pinfold/PrivacyHttpPlugin.java
@@ -83,12 +83,22 @@ public class PrivacyHttpPlugin extends Plugin {
         }
     };
 
+    /** Returns true only when the URL *hostname* ends with .b32.i2p. */
     private static boolean isI2P(String url) {
-        return url.contains(".b32.i2p");
+        try {
+            return new java.net.URI(url).getHost().endsWith(".b32.i2p");
+        } catch (Exception e) {
+            return false;
+        }
     }
 
+    /** Returns true only when the URL *hostname* ends with .onion. */
     private static boolean isTor(String url) {
-        return url.contains(".onion");
+        try {
+            return new java.net.URI(url).getHost().endsWith(".onion");
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     private OkHttpClient buildClient(String url, boolean followRedirects) {
@@ -268,6 +278,10 @@ public class PrivacyHttpPlugin extends Plugin {
             return;
         }
 
+        // Sanitize fileName: strip any path separators or null bytes to prevent
+        // path traversal on API < 29 where we write via File directly.
+        final String safeFileName = fileName.replaceAll("[/\\\\\\x00]", "_");
+
         new Thread(() -> {
             try {
                 byte[] bytes = Base64.decode(base64Data, Base64.DEFAULT);
@@ -275,7 +289,7 @@ public class PrivacyHttpPlugin extends Plugin {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     // API 29+ — use MediaStore to write to Downloads
                     ContentValues values = new ContentValues();
-                    values.put(MediaStore.Downloads.DISPLAY_NAME, fileName);
+                    values.put(MediaStore.Downloads.DISPLAY_NAME, safeFileName);
                     values.put(MediaStore.Downloads.MIME_TYPE, mimeType);
                     values.put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS);
 
@@ -296,7 +310,7 @@ public class PrivacyHttpPlugin extends Plugin {
                         os.flush();
                     }
 
-                    Log.d(TAG, "Saved " + fileName + " to Downloads via MediaStore (" + bytes.length + " bytes)");
+                    Log.d(TAG, "Saved " + safeFileName + " to Downloads via MediaStore (" + bytes.length + " bytes)");
                 } else {
                     // API < 29 — write directly to public Downloads folder
                     File downloadsDir = Environment.getExternalStoragePublicDirectory(
@@ -305,18 +319,18 @@ public class PrivacyHttpPlugin extends Plugin {
                     if (!downloadsDir.exists()) {
                         downloadsDir.mkdirs();
                     }
-                    File file = new File(downloadsDir, fileName);
+                    File file = new File(downloadsDir, safeFileName);
                     try (FileOutputStream fos = new FileOutputStream(file)) {
                         fos.write(bytes);
                         fos.flush();
                     }
 
-                    Log.d(TAG, "Saved " + fileName + " to " + file.getAbsolutePath() + " (" + bytes.length + " bytes)");
+                    Log.d(TAG, "Saved " + safeFileName + " to " + file.getAbsolutePath() + " (" + bytes.length + " bytes)");
                 }
 
                 JSObject result = new JSObject();
                 result.put("success", true);
-                result.put("fileName", fileName);
+                result.put("fileName", safeFileName);
                 call.resolve(result);
             } catch (Exception e) {
                 Log.e(TAG, "Failed to save to Downloads: " + e.getMessage(), e);

--- a/src/lib/api/pinterest.ts
+++ b/src/lib/api/pinterest.ts
@@ -44,9 +44,7 @@ export async function searchPins(query: string, bookmark?: string): Promise<Sear
 		}
 		const url = `${proxyBase}/search.php?${params}`;
 		const response = await httpGet(url, { skipProxy: true });
-		const result = parseBinternetSearchHtml(response.data as string);
-		console.log(`[Search] proxy search: ${result.pins.length} pins, bookmark=${result.bookmark ? 'yes' : 'no'}, data type=${typeof response.data}, data length=${typeof response.data === 'string' ? response.data.length : 'N/A'}`);
-		return result;
+		return parseBinternetSearchHtml(response.data as string);
 	}
 
 	const options: Record<string, unknown> = {
@@ -185,9 +183,7 @@ export async function getBoardPins(
 		}
 	});
 
-	const result = parseBoardFeedResponse(response.data);
-	console.log(`[Board] ${boardUrl} (id=${id}): ${result.pins.length} pins, bookmark=${result.bookmark ? 'yes' : 'no'}`);
-	return result;
+	return parseBoardFeedResponse(response.data);
 }
 
 /**

--- a/src/lib/stores/collages.svelte.ts
+++ b/src/lib/stores/collages.svelte.ts
@@ -130,8 +130,15 @@ export function encodeCollageShare(collage: Collage): string {
 	return btoa(payload).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
+export const MAX_COLLAGE_NAME_LENGTH = 200;
+export const MAX_SHARED_PINS = 500;
+// Pinterest pin IDs are numeric strings; reject anything else.
+const PIN_ID_RE = /^\d{1,20}$/;
+
 /**
  * Decode a share string back into a collage name and pin IDs.
+ * Enforces length limits and rejects non-numeric pin IDs to prevent
+ * unexpected API calls with attacker-controlled identifiers.
  */
 export function decodeCollageShare(data: string): { name: string; pinIds: string[] } | null {
 	try {
@@ -139,10 +146,12 @@ export function decodeCollageShare(data: string): { name: string; pinIds: string
 		const json = atob(base64);
 		const parsed = JSON.parse(json);
 		if (typeof parsed.n !== 'string' || !Array.isArray(parsed.p)) return null;
-		return {
-			name: parsed.n,
-			pinIds: parsed.p.map(String)
-		};
+		const name = parsed.n.slice(0, MAX_COLLAGE_NAME_LENGTH);
+		const pinIds = (parsed.p as unknown[])
+			.slice(0, MAX_SHARED_PINS)
+			.map(String)
+			.filter((id) => PIN_ID_RE.test(id));
+		return { name, pinIds };
 	} catch {
 		return null;
 	}

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -83,6 +83,10 @@ export function loadSettings(): void {
 		const stored = localStorage.getItem('pinfold-settings');
 		if (stored) {
 			const parsed = JSON.parse(stored) as Partial<AppSettings>;
+			// Reject an invalid proxy URL that may have been written by a tampered store.
+			if (parsed.proxyUrl !== undefined && !isValidProxyUrl(parsed.proxyUrl)) {
+				parsed.proxyUrl = '';
+			}
 			settings = { ...defaultSettings, ...parsed };
 		}
 	} catch {
@@ -127,7 +131,26 @@ async function applySystemBars(): Promise<void> {
 	}
 }
 
+/**
+ * Validate that a proxy URL is a well-formed http or https URL.
+ * Rejects javascript:, file:, data: and other non-network schemes.
+ */
+function isValidProxyUrl(url: string): boolean {
+	if (!url) return true; // empty = disabled, always valid
+	try {
+		const parsed = new URL(url);
+		return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+	} catch {
+		return false;
+	}
+}
+
 export function updateSettings(updates: Partial<AppSettings>): void {
+	if ('proxyUrl' in updates && updates.proxyUrl !== undefined) {
+		if (!isValidProxyUrl(updates.proxyUrl)) {
+			throw new Error('Proxy URL must be a valid http or https URL');
+		}
+	}
 	Object.assign(settings, updates);
 	saveSettings();
 	applyTheme();

--- a/src/lib/utils/http.ts
+++ b/src/lib/utils/http.ts
@@ -36,18 +36,28 @@ function getPinterestHeaders(): Record<string, string> {
 
 /**
  * Returns true for .b32.i2p addresses (I2P eepsites).
- * These require routing through the local I2P HTTP proxy (localhost:4444).
+ * Matches on the URL hostname only to avoid false positives from
+ * query parameters or path segments that contain these strings.
  */
 function isI2P(url: string): boolean {
-	return url.includes('.b32.i2p');
+	try {
+		return new URL(url).hostname.endsWith('.b32.i2p');
+	} catch {
+		return false;
+	}
 }
 
 /**
  * Returns true for .onion addresses (Tor hidden services).
- * These require routing through Tor SOCKS5 (localhost:9050).
+ * Matches on the URL hostname only to avoid false positives from
+ * query parameters or path segments that contain these strings.
  */
 function isTor(url: string): boolean {
-	return url.includes('.onion');
+	try {
+		return new URL(url).hostname.endsWith('.onion');
+	} catch {
+		return false;
+	}
 }
 
 /**
@@ -162,5 +172,6 @@ export async function httpPost(
 		assertJsonResponse(response.data, settings.proxyUrl);
 	}
 
+	assertOkStatus(response.status, requestUrl);
 	return { data: response.data, status: response.status, headers: response.headers };
 }

--- a/src/lib/utils/paste.ts
+++ b/src/lib/utils/paste.ts
@@ -58,24 +58,35 @@ export async function fetchPaste(key: string): Promise<string> {
 	return typeof response.data === 'string' ? response.data : JSON.stringify(response.data);
 }
 
+// Paste.rs keys are short alphanumeric identifiers (typically 3–6 chars).
+// Restrict to word characters only to prevent URL manipulation via
+// characters like '/', '?', '#', '\r', '\n' in the constructed request URL.
+const PASTE_KEY_RE = /^[\w-]{1,64}$/;
+
 /**
  * Extract the paste key from a full paste.rs URL or return
  * the input as-is if it's already just a key.
+ * Throws if the resulting key contains unsafe characters.
  */
 function extractPasteKey(input: string): string {
 	const trimmed = input.trim();
 
+	let key = trimmed;
 	try {
 		const url = new URL(trimmed);
 		if (url.hostname === 'paste.rs') {
 			const parts = url.pathname.split('/').filter(Boolean);
 			if (parts.length > 0) {
-				return parts[0];
+				key = parts[0];
 			}
 		}
 	} catch {
 		// Not a URL, treat as raw key
 	}
 
-	return trimmed;
+	if (!PASTE_KEY_RE.test(key)) {
+		throw new Error('Invalid paste key format');
+	}
+
+	return key;
 }

--- a/src/routes/collages/shared/+page.svelte
+++ b/src/routes/collages/shared/+page.svelte
@@ -4,7 +4,7 @@
 	import MasonryGrid from '$lib/components/MasonryGrid.svelte';
 	import PinCard from '$lib/components/PinCard.svelte';
 	import LoadingGrid from '$lib/components/LoadingGrid.svelte';
-	import { decodeCollageShare, duplicateCollage } from '$lib/stores/collages.svelte.ts';
+	import { decodeCollageShare, duplicateCollage, MAX_COLLAGE_NAME_LENGTH, MAX_SHARED_PINS } from '$lib/stores/collages.svelte.ts';
 	import { fetchPaste } from '$lib/utils/paste.ts';
 	import { getPin } from '$lib/api/pinterest.ts';
 	import type { Pin } from '$lib/api/types.ts';
@@ -50,8 +50,13 @@
 				throw new Error('Invalid collage data format');
 			}
 
-			collageName = parsed.n;
-			const pinIds: string[] = parsed.p.map(String);
+			// Apply the same limits and pin ID validation as decodeCollageShare.
+			const PIN_ID_RE = /^\d{1,20}$/;
+			collageName = parsed.n.slice(0, MAX_COLLAGE_NAME_LENGTH);
+			const pinIds: string[] = (parsed.p as unknown[])
+				.slice(0, MAX_SHARED_PINS)
+				.map(String)
+				.filter((id) => PIN_ID_RE.test(id));
 			totalCount = pinIds.length;
 
 			if (pinIds.length === 0) {

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -8,14 +8,25 @@
 	let themeColor = $state(settings.current.themeColor);
 	let themeMode = $state(settings.current.theme);
 	let showInstances = $state(false);
+	let proxyError = $state<string | null>(null);
 
 	function saveProxy() {
-		settings.update({ proxyUrl: proxyUrl.trim() });
+		try {
+			settings.update({ proxyUrl: proxyUrl.trim() });
+			proxyError = null;
+		} catch (e) {
+			proxyError = e instanceof Error ? e.message : 'Invalid proxy URL';
+		}
 	}
 
 	function selectInstance(url: string) {
 		proxyUrl = url;
-		settings.update({ proxyUrl: url });
+		try {
+			settings.update({ proxyUrl: url });
+			proxyError = null;
+		} catch (e) {
+			proxyError = e instanceof Error ? e.message : 'Invalid proxy URL';
+		}
 		showInstances = false;
 	}
 
@@ -141,6 +152,10 @@
 				Save
 			</button>
 		</div>
+
+		{#if proxyError}
+			<p class="mt-1 text-xs text-error">{proxyError}</p>
+		{/if}
 
 		{#if proxyUrl}
 			<button


### PR DESCRIPTION
- Path traversal (PrivacyHttpPlugin): sanitize fileName before passing to File constructor on API < 29; strip '/', '\', and null bytes.
- Paste key injection (paste.ts): restrict keys to word chars (\w-) max 64 chars via regex; prevents '/', '?', '#' from altering the constructed paste.rs URL.
- Proxy URL validation (settings.svelte.ts): reject non-http/https schemes (javascript:, file:, data:) on updateSettings() and on load from localStorage; surface error in settings UI.
- Debug log removal (pinterest.ts): remove console.log calls that leaked board URLs and pagination tokens at runtime.
- httpPost status check (http.ts): call assertOkStatus() in httpPost consistent with httpGet, so 4xx/5xx responses are not silently swallowed.
- isI2P / isTor hostname matching (http.ts, PrivacyHttpPlugin.java): match on URL hostname instead of raw string to prevent false positives from query parameters or path segments.
- Collage share input validation (collages.svelte.ts, shared page): cap name to 200 chars, pin list to 500 entries, and reject non-numeric pin IDs (regex /^\d{1,20}$/) to prevent unexpected API calls with attacker-controlled identifiers.

