### PR TITLE
Fix tar vulnerability by upgrading @capacitor/cli to v7.5.0

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -2,8 +2,8 @@
 
 android {
   compileOptions {
-      sourceCompatibility JavaVersion.VERSION_17
-      targetCompatibility JavaVersion.VERSION_17
+      sourceCompatibility JavaVersion.VERSION_21
+      targetCompatibility JavaVersion.VERSION_21
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@capacitor/android": "^6.0.0",
 				"@capacitor/app": "^6.0.3",
-				"@capacitor/cli": "^6.0.0",
+				"@capacitor/cli": "^7.5.0",
 				"@capacitor/core": "^6.0.0",
 				"@capacitor/filesystem": "^6.0.0",
 				"@capacitor/haptics": "^6.0.0",
@@ -50,35 +50,49 @@
 			}
 		},
 		"node_modules/@capacitor/cli": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-6.2.1.tgz",
-			"integrity": "sha512-JKl0FpFge8PgQNInw12kcKieQ4BmOyazQ4JGJOfEpVXlgrX1yPhSZTPjngupzTCiK3I7q7iGG5kjun0fDqgSCA==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-7.5.0.tgz",
+			"integrity": "sha512-mlohsvLZjWrO5eAVTn1+dABNQwQawcphVp6NQVJZ3I4x2BAoNmJj53QflX7PYGUipL9gF9EM9Yiku3m1McxFZg==",
 			"license": "MIT",
 			"dependencies": {
-				"@ionic/cli-framework-output": "^2.2.5",
-				"@ionic/utils-fs": "^3.1.6",
-				"@ionic/utils-subprocess": "2.1.11",
-				"@ionic/utils-terminal": "^2.3.3",
-				"commander": "^9.3.0",
-				"debug": "^4.3.4",
+				"@ionic/cli-framework-output": "^2.2.8",
+				"@ionic/utils-subprocess": "^3.0.1",
+				"@ionic/utils-terminal": "^2.3.5",
+				"commander": "^12.1.0",
+				"debug": "^4.4.0",
 				"env-paths": "^2.2.0",
-				"kleur": "^4.1.4",
-				"native-run": "^2.0.0",
+				"fs-extra": "^11.2.0",
+				"kleur": "^4.1.5",
+				"native-run": "^2.0.3",
 				"open": "^8.4.0",
-				"plist": "^3.0.5",
+				"plist": "^3.1.0",
 				"prompts": "^2.4.2",
-				"rimraf": "^4.4.1",
-				"semver": "^7.3.7",
-				"tar": "^6.1.11",
-				"tslib": "^2.4.0",
-				"xml2js": "^0.5.0"
+				"rimraf": "^6.0.1",
+				"semver": "^7.6.3",
+				"tar": "^7.5.3",
+				"tslib": "^2.8.1",
+				"xml2js": "^0.6.2"
 			},
 			"bin": {
 				"cap": "bin/capacitor",
 				"capacitor": "bin/capacitor"
 			},
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@capacitor/cli/node_modules/fs-extra": {
+			"version": "11.3.4",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+			"integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
 			}
 		},
 		"node_modules/@capacitor/core": {
@@ -601,16 +615,16 @@
 			}
 		},
 		"node_modules/@ionic/utils-array": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@ionic/utils-array/-/utils-array-2.1.5.tgz",
-			"integrity": "sha512-HD72a71IQVBmQckDwmA8RxNVMTbxnaLbgFOl+dO5tbvW9CkkSFCv41h6fUuNsSEVgngfkn0i98HDuZC8mk+lTA==",
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/@ionic/utils-array/-/utils-array-2.1.6.tgz",
+			"integrity": "sha512-0JZ1Zkp3wURnv8oq6Qt7fMPo5MpjbLoUoa9Bu2Q4PJuSDWM8H8gwF3dQO7VTeUj3/0o1IB1wGkFWZZYgUXZMUg==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.0.0",
 				"tslib": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=10.3.0"
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/@ionic/utils-fs": {
@@ -629,120 +643,65 @@
 			}
 		},
 		"node_modules/@ionic/utils-object": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-2.1.5.tgz",
-			"integrity": "sha512-XnYNSwfewUqxq+yjER1hxTKggftpNjFLJH0s37jcrNDwbzmbpFTQTVAp4ikNK4rd9DOebX/jbeZb8jfD86IYxw==",
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-2.1.6.tgz",
+			"integrity": "sha512-vCl7sl6JjBHFw99CuAqHljYJpcE88YaH2ZW4ELiC/Zwxl5tiwn4kbdP/gxi2OT3MQb1vOtgAmSNRtusvgxI8ww==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.0.0",
 				"tslib": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=10.3.0"
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/@ionic/utils-process": {
-			"version": "2.1.10",
-			"resolved": "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-2.1.10.tgz",
-			"integrity": "sha512-mZ7JEowcuGQK+SKsJXi0liYTcXd2bNMR3nE0CyTROpMECUpJeAvvaBaPGZf5ERQUPeWBVuwqAqjUmIdxhz5bxw==",
+			"version": "2.1.12",
+			"resolved": "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-2.1.12.tgz",
+			"integrity": "sha512-Jqkgyq7zBs/v/J3YvKtQQiIcxfJyplPgECMWgdO0E1fKrrH8EF0QGHNJ9mJCn6PYe2UtHNS8JJf5G21e09DfYg==",
 			"license": "MIT",
 			"dependencies": {
-				"@ionic/utils-object": "2.1.5",
-				"@ionic/utils-terminal": "2.3.3",
+				"@ionic/utils-object": "2.1.6",
+				"@ionic/utils-terminal": "2.3.5",
 				"debug": "^4.0.0",
 				"signal-exit": "^3.0.3",
 				"tree-kill": "^1.2.2",
 				"tslib": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=10.3.0"
-			}
-		},
-		"node_modules/@ionic/utils-process/node_modules/@ionic/utils-terminal": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.3.tgz",
-			"integrity": "sha512-RnuSfNZ5fLEyX3R5mtcMY97cGD1A0NVBbarsSQ6yMMfRJ5YHU7hHVyUfvZeClbqkBC/pAqI/rYJuXKCT9YeMCQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/slice-ansi": "^4.0.0",
-				"debug": "^4.0.0",
-				"signal-exit": "^3.0.3",
-				"slice-ansi": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0",
-				"tslib": "^2.0.1",
-				"untildify": "^4.0.0",
-				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=10.3.0"
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/@ionic/utils-stream": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-3.1.5.tgz",
-			"integrity": "sha512-hkm46uHvEC05X/8PHgdJi4l4zv9VQDELZTM+Kz69odtO9zZYfnt8DkfXHJqJ+PxmtiE5mk/ehJWLnn/XAczTUw==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-3.1.7.tgz",
+			"integrity": "sha512-eSELBE7NWNFIHTbTC2jiMvh1ABKGIpGdUIvARsNPMNQhxJB3wpwdiVnoBoTYp+5a6UUIww4Kpg7v6S7iTctH1w==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.0.0",
 				"tslib": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=10.3.0"
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/@ionic/utils-subprocess": {
-			"version": "2.1.11",
-			"resolved": "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-2.1.11.tgz",
-			"integrity": "sha512-6zCDixNmZCbMCy5np8klSxOZF85kuDyzZSTTQKQP90ZtYNCcPYmuFSzaqDwApJT4r5L3MY3JrqK1gLkc6xiUPw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-3.0.1.tgz",
+			"integrity": "sha512-cT4te3AQQPeIM9WCwIg8ohroJ8TjsYaMb2G4ZEgv9YzeDqHZ4JpeIKqG2SoaA3GmVQ3sOfhPM6Ox9sxphV/d1A==",
 			"license": "MIT",
 			"dependencies": {
-				"@ionic/utils-array": "2.1.5",
-				"@ionic/utils-fs": "3.1.6",
-				"@ionic/utils-process": "2.1.10",
-				"@ionic/utils-stream": "3.1.5",
-				"@ionic/utils-terminal": "2.3.3",
+				"@ionic/utils-array": "2.1.6",
+				"@ionic/utils-fs": "3.1.7",
+				"@ionic/utils-process": "2.1.12",
+				"@ionic/utils-stream": "3.1.7",
+				"@ionic/utils-terminal": "2.3.5",
 				"cross-spawn": "^7.0.3",
 				"debug": "^4.0.0",
 				"tslib": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=10.3.0"
-			}
-		},
-		"node_modules/@ionic/utils-subprocess/node_modules/@ionic/utils-fs": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.6.tgz",
-			"integrity": "sha512-eikrNkK89CfGPmexjTfSWl4EYqsPSBh0Ka7by4F0PLc1hJZYtJxUZV3X4r5ecA8ikjicUmcbU7zJmAjmqutG/w==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/fs-extra": "^8.0.0",
-				"debug": "^4.0.0",
-				"fs-extra": "^9.0.0",
-				"tslib": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=10.3.0"
-			}
-		},
-		"node_modules/@ionic/utils-subprocess/node_modules/@ionic/utils-terminal": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.3.tgz",
-			"integrity": "sha512-RnuSfNZ5fLEyX3R5mtcMY97cGD1A0NVBbarsSQ6yMMfRJ5YHU7hHVyUfvZeClbqkBC/pAqI/rYJuXKCT9YeMCQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/slice-ansi": "^4.0.0",
-				"debug": "^4.0.0",
-				"signal-exit": "^3.0.3",
-				"slice-ansi": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0",
-				"tslib": "^2.0.1",
-				"untildify": "^4.0.0",
-				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=10.3.0"
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/@ionic/utils-terminal": {
@@ -775,15 +734,6 @@
 			},
 			"engines": {
 				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@isaacs/fs-minipass/node_modules/minipass": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -1703,10 +1653,13 @@
 			}
 		},
 		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"license": "MIT"
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -1750,12 +1703,15 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/buffer-crc32": {
@@ -1821,12 +1777,12 @@
 			"license": "MIT"
 		},
 		"node_modules/commander": {
-			"version": "9.5.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
 			"license": "MIT",
 			"engines": {
-				"node": "^12.20.0 || >=14"
+				"node": ">=18"
 			}
 		},
 		"node_modules/cookie": {
@@ -2052,12 +2008,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"license": "ISC"
-		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2074,19 +2024,17 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "9.3.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-			"integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"license": "ISC",
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"minimatch": "^8.0.2",
-				"minipass": "^4.2.4",
-				"path-scurry": "^1.6.1"
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -2465,10 +2413,13 @@
 			"license": "MIT"
 		},
 		"node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"license": "ISC"
+			"version": "11.2.6",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+			"integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
@@ -2481,27 +2432,27 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "8.0.7",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
-			"integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
-			"license": "ISC",
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.2"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/minipass": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-			"integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-			"license": "ISC",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=8"
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/minizlib": {
@@ -2514,15 +2465,6 @@
 			},
 			"engines": {
 				"node": ">= 18"
-			}
-		},
-		"node_modules/minizlib/node_modules/minipass": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/mri": {
@@ -2623,6 +2565,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"license": "BlueOak-1.0.0"
+		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -2633,28 +2581,19 @@
 			}
 		},
 		"node_modules/path-scurry": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"lru-cache": "^10.2.0",
-				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.18"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/path-scurry/node_modules/minipass": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/pend": {
@@ -2777,18 +2716,19 @@
 			}
 		},
 		"node_modules/rimraf": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
-			"integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
-			"license": "ISC",
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+			"integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"glob": "^9.2.0"
+				"glob": "^13.0.3",
+				"package-json-from-dist": "^1.0.1"
 			},
 			"bin": {
-				"rimraf": "dist/cjs/src/bin.js"
+				"rimraf": "dist/esm/bin.mjs"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -3105,15 +3045,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/tar/node_modules/minipass": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/through2": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
@@ -3337,9 +3268,9 @@
 			}
 		},
 		"node_modules/xml2js": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-			"integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
 			"license": "MIT",
 			"dependencies": {
 				"sax": ">=0.6.0",

--- a/package.json
+++ b/package.json
@@ -24,13 +24,12 @@
 		"vite": "^7.3.1"
 	},
 	"overrides": {
-		"cookie": ">=0.7.0",
-		"tar": ">=7.5.8"
+		"cookie": ">=0.7.0"
 	},
 	"dependencies": {
 		"@capacitor/android": "^6.0.0",
 		"@capacitor/app": "^6.0.3",
-		"@capacitor/cli": "^6.0.0",
+		"@capacitor/cli": "^7.5.0",
 		"@capacitor/core": "^6.0.0",
 		"@capacitor/filesystem": "^6.0.0",
 		"@capacitor/haptics": "^6.0.0",


### PR DESCRIPTION
The tar override broke cap sync because @capacitor/cli@6 relies on tar's internal extract API which changed in newer versions. Instead, upgrade @capacitor/cli to ^7.5.0 which bundles tar@^7.5.3 (non- vulnerable) and is compatible with the existing @capacitor/android@6 runtime. Remove the tar override and keep only the cookie override.

https://claude.ai/code/session_0163HMuRCPagTpMwECfDTDmd